### PR TITLE
Restore COMPONENT_NAME variable

### DIFF
--- a/dhizuku-api/src/main/java/com/rosan/dhizuku/shared/DhizukuVariables.java
+++ b/dhizuku-api/src/main/java/com/rosan/dhizuku/shared/DhizukuVariables.java
@@ -1,5 +1,6 @@
 package com.rosan.dhizuku.shared;
 
+import android.content.ComponentName;
 import android.os.Binder;
 
 import java.util.Objects;
@@ -7,7 +8,9 @@ import java.util.Objects;
 public class DhizukuVariables {
     public static final String OFFICIAL_PACKAGE_NAME = "com.rosan.dhizuku";
 
-    public static final String PERMISSION_API = "com.rosan.dhizuku.permission.API";
+    public static final String PERMISSION_API = OFFICIAL_PACKAGE_NAME + ".permission.API";
+
+    public static final ComponentName COMPONENT_NAME = new ComponentName(OFFICIAL_PACKAGE_NAME, OFFICIAL_PACKAGE_NAME + ".server.DhizukuDAReceiver");
 
     public static String getProviderAuthorityName(String packageName) {
         if (Objects.equals(packageName, OFFICIAL_PACKAGE_NAME))


### PR DESCRIPTION
<https://github.com/iamr0s/Dhizuku-API/blob/v2.4/dhizuku-shared/src/main/java/com/rosan/dhizuku/shared/DhizukuVariables.java#L9>
```java
    public static final ComponentName COMPONENT_NAME = new ComponentName(PACKAGE_NAME, PACKAGE_NAME + ".server.DhizukuDAReceiver");
```

I'd like to see this constant brought back, it was used by many developers.