### PR TITLE
Deleted headless system mode, which caused problems for multiple devices

### DIFF
--- a/dhizuku-server_api/src/main/res/xml/dhizuku_device_admin.xml
+++ b/dhizuku-server_api/src/main/res/xml/dhizuku_device_admin.xml
@@ -14,5 +14,4 @@
     </uses-policies>
     <!--suppress AndroidElementNotAllowed -->
     <support-transfer-ownership />
-    <headless-system-user headless-device-owner-mode="single_user" device-owner-mode="single_user" />
 </device-admin>


### PR DESCRIPTION
Many people ([wzlLucas](https://github.com/iamr0s/Dhizuku/issues/257), [justinkb](https://github.com/iamr0s/Dhizuku-API/issues/34), and myself) had had problems with getting dhizuku to activate. The problem seems to be, reported by [justinkb](https://github.com/iamr0s/Dhizuku-API/issues/34) ([2](https://github.com/iamr0s/Dhizuku/issues/204#issuecomment-3611583792)) and [codesenlin](https://github.com/iamr0s/Dhizuku/issues/277), that the line 

\"
<headless-system-user device-owner-mode=\"single_user\" headless-device-owner-mode=\"single_user\" />
\"

seems to be causing problems for non "specialized headless system user devices." ([justinkb\'s post](https://github.com/iamr0s/Dhizuku-API/issues/34)) This fork removes this line, fixing the problem.